### PR TITLE
Fixed check digit function for EAN-13

### DIFF
--- a/NetBarcode/Types/EAN13.cs
+++ b/NetBarcode/Types/EAN13.cs
@@ -257,7 +257,7 @@ namespace NetBarcode.Types
         {
             try
             {
-                var rawDataHolder = _data.Substring(0, 12);
+                var rawDataHolder = data.Substring(0, 12);
 
                 var even = 0;
                 var odd = 0;


### PR DESCRIPTION
I've noticed that, when trying to generate the image for a EAN-13 bar code, I always got an exception in CheckDigit(), even though all the codes I used were either coming from real-world articles or had been checked against the GS1 online tool. 

This pull request fixes the issue with EAN-13 CheckDigit() method. Please release an updated NuGet package too. 