### PR TITLE
Upgrade to .net6

### DIFF
--- a/NetBarcode/Barcode.cs
+++ b/NetBarcode/Barcode.cs
@@ -621,16 +621,16 @@ namespace NetBarcode
             }
 
             float labelHeight = 0F, labelWidth = 0F;
-            TextOptions labelTextOptions = null;
+            RichTextOptions labelTextOptions = null;
 
             if (_showLabel)
             {
-                labelTextOptions = new TextOptions(GetEffeciveFont())
+                labelTextOptions = new RichTextOptions(GetEffeciveFont())
                 {
                     Dpi = 200,
                 };
 
-                var labelSize = TextMeasurer.Measure(_data, labelTextOptions);
+                var labelSize = TextMeasurer.MeasureAdvance(_data, labelTextOptions);
                 labelHeight = labelSize.Height;
                 labelWidth = labelSize.Width;
             }
@@ -670,7 +670,7 @@ namespace NetBarcode
                 imageContext.BackgroundColor(_backgroundColor);
 
                 //lines are fBarWidth wide so draw the appropriate color line vertically
-                var pen = new Pen(_foregroundColor, iBarWidth / iBarWidthModifier);
+                var pen = new SolidPen(_foregroundColor, iBarWidth / iBarWidthModifier);
                 var drawingOptions = new DrawingOptions
                 {
                     GraphicsOptions = new GraphicsOptions
@@ -684,7 +684,7 @@ namespace NetBarcode
                 {
                     if (_encodedData[pos] == '1')
                     {
-                        imageContext.DrawLines(drawingOptions, pen,
+                        imageContext.DrawLine(drawingOptions, pen,
                             new PointF(pos * iBarWidth + shiftAdjustment + halfBarWidth, 0),
                             new PointF(pos * iBarWidth + shiftAdjustment + halfBarWidth, _height - labelHeight)
                         );

--- a/NetBarcode/NetBarcode.csproj
+++ b/NetBarcode/NetBarcode.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <PackageProjectUrl>https://github.com/Tagliatti/NetBarcode</PackageProjectUrl>
     <PackageTags>barcode</PackageTags>
     <PackageIconUrl>https://i.imgur.com/BhcO3DF.jpg</PackageIconUrl>
@@ -10,14 +10,14 @@
     <Authors>Filipe Tagliatti</Authors>
     <Company />
     <Product />
-    <Description>Barcode generation library written in .NET Core compatible with .NET Standard 2.</Description>
+    <Description>Barcode generation library written in .NET Core compatible with .NET 6.</Description>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
     <DocumentationFile>bin\$(Configuration)\netstandard2.0\NetBarcode.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta17" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta14" />
+    <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.6" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/NetBarcode/Properties/PublishProfiles/FolderProfile net6.0.pubxml
+++ b/NetBarcode/Properties/PublishProfiles/FolderProfile net6.0.pubxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>AnyCPU</LastUsedPlatform>
+    <publishUrl>../../Release/SDK/NetBarcode</publishUrl>
+    <DeleteExistingFiles>false</DeleteExistingFiles>
+    <TargetFramework>net6.0</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <_IsPortable>true</_IsPortable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Hi,

Due to IronPDF version 2023.10.3 is using SixLabors version 1.0.0 and above, caused conflict with NetBarcode version and throwed exception of Method missing.

1. Update Target Framework to .net6.
2. Update dependency package.
3. Update the method which is no longer in new version of the package.