### PR TITLE
Additional check when looking for effective font

### DIFF
--- a/NetBarcode/Barcode.cs
+++ b/NetBarcode/Barcode.cs
@@ -739,7 +739,7 @@ namespace NetBarcode
 
             var defaultFont = SystemFonts.Collection.Families.FirstOrDefault();
 
-            if (defaultFont == null)
+            if (defaultFont == null || defaultFont.Name == null)
                 throw new Exception("Label font not specified and no installed fonts found.");
 
             return _labelFont = SystemFonts.CreateFont(defaultFont.Name, 10, FontStyle.Bold);


### PR DESCRIPTION
Make sure a default font has been found by checking if its null, or if Name is null.
Should fix issues like #39. Let me know what you think.